### PR TITLE
Batch fixes to use crystal 0.25.0 (I believe - it will help at least)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ All code in `src/time_zone/data` folder is automatically generated so please don
 
 ## Contributors
 
-* [imdrasil](https://github.com/[your-github-name]) Roman Kalnytskyi - creator, maintainer
+* [imdrasil](https://github.com/imdrasil) Roman Kalnytskyi - creator, maintainer

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -24,7 +24,7 @@ def Time.expect_invalid
 end
 
 def expect_raises_ambiguous_time(time)
-  Spec::Expectations.expect_raises(TimeZone::AmbiguousTime, "#{time.to_s("%Y-%m-%d %H:%M:%S")} is an ambiguous local time") do
+  expect_raises(TimeZone::AmbiguousTime, "#{time.to_s("%Y-%m-%d %H:%M:%S")} is an ambiguous local time") do
     yield
   end
 end

--- a/src/time_zone/time.cr
+++ b/src/time_zone/time.cr
@@ -198,7 +198,7 @@ module TimeZone
     end
 
     def to_time
-      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, kind: nil)
+      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, location: ::Time::Location.load("UTC"))
     end
   end
 end

--- a/src/time_zone/time.cr
+++ b/src/time_zone/time.cr
@@ -17,7 +17,7 @@ module TimeZone
       Zone.default.new(seconds, nanoseconds)
     end
 
-    def self.new(time : LibC::Timespec, _kind = Kind::Utc)
+    def self.new(time : LibC::Timespec, _kind = nil)
       seconds = UNIX_SECONDS + time.tv_sec
       nanoseconds = time.tv_nsec.to_i
       Zone.default.new(seconds: seconds, nanoseconds: nanoseconds)
@@ -198,7 +198,7 @@ module TimeZone
     end
 
     def to_time
-      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, kind: Kind::Utc)
+      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, kind: nil)
     end
   end
 end

--- a/src/time_zone/time.cr
+++ b/src/time_zone/time.cr
@@ -198,7 +198,7 @@ module TimeZone
     end
 
     def to_time
-      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, location: ::Time::Location.load("UTC"))
+      ::Time.new(seconds: @seconds, nanoseconds: @nanoseconds, location: ::Time::Location::UTC)
     end
   end
 end

--- a/src/time_zone/time/canonical_time_instance_methods.cr
+++ b/src/time_zone/time/canonical_time_instance_methods.cr
@@ -1,7 +1,7 @@
 module TimeZone
   struct Time
     module CanonicalTimeInstanceMethods
-      alias Kind = ::Time::Kind
+      # alias Kind = ::Time::Kind
       alias DayOfWeek = ::Time::DayOfWeek
       alias Span = ::Time::Span
       alias MonthSpan = ::Time::MonthSpan
@@ -102,7 +102,7 @@ module TimeZone
       end
 
       # Returns `Kind` (UTC/local) of the instance.
-      def kind : Kind
+      def kind # : Kind
         @kind
       end
 

--- a/src/time_zone/time/formatter.cr
+++ b/src/time_zone/time/formatter.cr
@@ -179,7 +179,7 @@ module TimeZone
       end
 
       def get_month_name
-        MONTH_NAMES[time.month - 1]
+        ::Time::Format::MONTH_NAMES[time.month - 1]
       end
 
       def get_short_month_name
@@ -187,7 +187,7 @@ module TimeZone
       end
 
       def get_day_name
-        DAY_NAMES[time.day_of_week.value]
+        ::Time::Format::DAY_NAMES[time.day_of_week.value]
       end
 
       def get_short_day_name

--- a/src/time_zone/time/parser.cr
+++ b/src/time_zone/time/parser.cr
@@ -65,7 +65,7 @@ module TimeZone
         end
 
         string = string.capitalize
-        index = MONTH_NAMES.index &.starts_with?(string)
+        index = ::Time::Format::MONTH_NAMES.index &.starts_with?(string)
         if index
           @month = 1 + index
         else
@@ -104,7 +104,7 @@ module TimeZone
         end
 
         string = string.capitalize
-        index = DAY_NAMES.index &.starts_with?(string)
+        index = ::Time::Format::DAY_NAMES.index &.starts_with?(string)
         unless index
           ::raise "Invalid day name"
         end


### PR DESCRIPTION
- fixes `#expect_raises_ambiguous_time`
- depracates `Time::Kind` and any relevant constants
- fixes `::Time::Format` related constant lookup
